### PR TITLE
Fixing Bolt deprecations

### DIFF
--- a/inventory.yaml
+++ b/inventory.yaml
@@ -1,6 +1,6 @@
 groups:
   - name: linux
-    nodes:
+    targets:
       - 1.2.3.4
     config:
       transport: ssh
@@ -10,7 +10,7 @@ groups:
         run-as: root
         private-key: /path/to/key
   - name: windows
-    nodes:
+    targets:
       - 5.6.7.8
     config:
       transport: winrm

--- a/site-modules/tools/plans/timesync.pp
+++ b/site-modules/tools/plans/timesync.pp
@@ -1,6 +1,6 @@
 plan tools::timesync(
-  TargetSpec $nodes,
+  TargetSpec $targets,
 ) {
-  run_task('tools::timesync', $nodes, restart => false)
-  run_task('service::windows', $nodes, name => 'W32Time', action => 'restart')
+  run_task('tools::timesync', $targets, restart => false)
+  run_task('service::windows', $targets, name => 'W32Time', action => 'restart')
 }

--- a/site-modules/tools/plans/timesync_code.pp
+++ b/site-modules/tools/plans/timesync_code.pp
@@ -1,9 +1,9 @@
 plan tools::timesync_code(
-  TargetSpec $nodes,
+  TargetSpec $targets,
 ) {
-  apply_prep($nodes)
+  apply_prep($targets)
 
-  apply($nodes) {
+  apply($targets) {
     class { 'windowstime':
       servers  => { '0.nl.pool.ntp.org' => '0x08',
                     '1.nl.pool.ntp.org' => '0x08',


### PR DESCRIPTION
Pretty easy one here: people in workshops get failures or deprecation warnings about nodes instead of targets.